### PR TITLE
issue-55-56

### DIFF
--- a/includes/class-alg-wc-custom-post-type-for-order-statuses.php
+++ b/includes/class-alg-wc-custom-post-type-for-order-statuses.php
@@ -329,16 +329,16 @@ if ( ! class_exists( 'Alg_WC_Custom_Post_Type_For_Order_Statuses' ) ) {
 		 */
 		public function alg_my_display_callback( $post ) {
 			if ( '' !== get_post_meta( $post->ID, 'status_slug', true ) ) {
-				$readonly = 'readonly';
+				$slug_readonly = 'readonly';
 			} else {
-				$readonly = '';
+				$slug_readonly = '';
 			}
 			?>
 				<table class="form-table">
 					<tbody>
 						<tr>
 							<th><?php esc_html_e( 'Slug', 'custom-order-statuses-woocommerce' ); ?></th>
-							<td><input required="" type="text" onkeyup="check_status_slug(this);" name="new_status_slug" value="<?php echo esc_attr( get_post_meta( $post->ID, 'status_slug', true ) ); ?>" <?php echo esc_attr( $readonly ); ?>>
+							<td><input required="" type="text" onkeyup="check_status_slug(this);" name="new_status_slug" value="<?php echo esc_attr( get_post_meta( $post->ID, 'status_slug', true ) ); ?>" <?php echo esc_attr( $slug_readonly ); ?>>
 							<br><em><?php /* translators: $s: wc string */ printf( esc_attr__( '* Without %s prefix,', 'custom-order-statuses-woocommerce' ), '<code>wc-</code>' ); ?>
 							<?php esc_html_e( '17 characters max.', 'custom-order-statuses-woocommerce' ); ?></em>
 							</td>

--- a/includes/class-alg-wc-custom-post-type-for-order-statuses.php
+++ b/includes/class-alg-wc-custom-post-type-for-order-statuses.php
@@ -328,12 +328,17 @@ if ( ! class_exists( 'Alg_WC_Custom_Post_Type_For_Order_Statuses' ) ) {
 		 * @author  Tyche Softwares
 		 */
 		public function alg_my_display_callback( $post ) {
+			if ( '' !== get_post_meta( $post->ID, 'status_slug', true ) ) {
+				$readonly = 'readonly';
+			} else {
+				$readonly = '';
+			}
 			?>
 				<table class="form-table">
 					<tbody>
 						<tr>
 							<th><?php esc_html_e( 'Slug', 'custom-order-statuses-woocommerce' ); ?></th>
-							<td><input required="" type="text" onkeyup="check_status_slug(this);" name="new_status_slug" value="<?php echo esc_attr( get_post_meta( $post->ID, 'status_slug', true ) ); ?>">
+							<td><input required="" type="text" onkeyup="check_status_slug(this);" name="new_status_slug" value="<?php echo esc_attr( get_post_meta( $post->ID, 'status_slug', true ) ); ?>" <?php echo esc_attr( $readonly ); ?>>
 							<br><em><?php /* translators: $s: wc string */ printf( esc_attr__( '* Without %s prefix,', 'custom-order-statuses-woocommerce' ), '<code>wc-</code>' ); ?>
 							<?php esc_html_e( '17 characters max.', 'custom-order-statuses-woocommerce' ); ?></em>
 							</td>


### PR DESCRIPTION
When we edit the slug in cos, orders were getting removed from the orders page for that cos. So now in this commit, it is fixed as the slug is not editable after it is saved.

Fixes #55

Fixes #56